### PR TITLE
Fix typo in tricot.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.4.2] - June 11, 2021
+
+### Changed
+
+* Fix typo within ``tricot.py`` that caused an error when using the ``--tester`` option
+
+
 ## [1.4.1] - May 28, 2021
 
 ### Changed

--- a/bin/tricot
+++ b/bin/tricot
@@ -10,7 +10,7 @@ import tricot
 import argparse
 
 
-parser = argparse.ArgumentParser(description='''tricot v1.4.1 - a trivial command tester that allows you to verify that certain
+parser = argparse.ArgumentParser(description='''tricot v1.4.2 - a trivial command tester that allows you to verify that certain
                                                 commands or executables behave as expected. It uses .yml files for test
                                                 definitions and can be used from the command line or as a python library.''')
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
     url='https://github.com/qtc-de/tricot',
     name='tricot',
     author='Tobias Neitzel (@qtc_de)',
-    version='1.4.1',
+    version='1.4.2',
     author_email='',
 
     description='Trivial Command Testser',

--- a/tricot/tricot.py
+++ b/tricot/tricot.py
@@ -643,7 +643,7 @@ class Tester:
             try:
 
                 if self.name in testers:
-                    tester.run(numbers=numbers, exluce=exclude, hotplug_variables=hotplug_variables)
+                    tester.run(numbers=numbers, exclude=exclude, hotplug_variables=hotplug_variables)
 
                 else:
                     tester.run(testers, numbers, exclude, hotplug_variables)


### PR DESCRIPTION
Fixed a typo that only causes an error when the --tester option is used.